### PR TITLE
s3-fix: Add conditional logic to account for s3 bucket structure

### DIFF
--- a/soundboard.js
+++ b/soundboard.js
@@ -330,7 +330,11 @@ class SoundBoard {
         SoundBoard.soundsLoaded = false;
         try {
             SoundBoard.sounds = {};
-            var soundboardDirArray = await FilePicker.browse(source, game.settings.get("SoundBoard", "soundboardDirectory"));
+            if (source === 's3') {
+                const bucketContainer = await FilePicker.browse(source, game.settings.get('SoundBoard', 'soundboardDirectory'));
+                var bucket = bucketContainer.dirs[0]
+            }
+            var soundboardDirArray = await FilePicker.browse(source, game.settings.get("SoundBoard", "soundboardDirectory"), {...(bucket && {bucket})});
             if (soundboardDirArray.target != game.settings.get("SoundBoard", "soundboardDirectory")) {
                 throw "Filepicker target did not match input. Parent directory may be correct. Soft failure.";
             }
@@ -339,9 +343,9 @@ class SoundBoard {
             for (const dir of soundboardDirArray.dirs) {
                 const dirShortName = dir.split(/[\/]+/).pop();
                 SoundBoard.sounds[dirShortName] = [];
-                let innerDirArray = await FilePicker.browse(source, dir);
+                let innerDirArray = await FilePicker.browse(source, dir, {...(bucket && {bucket})});
                 for (const wildcardDir of innerDirArray.dirs) {
-                    let wildcardFileArray = await FilePicker.browse(source, wildcardDir);
+                    let wildcardFileArray = await FilePicker.browse(source, wildcardDir, {...(bucket && {bucket})});
                     wildcardFileArray = wildcardFileArray.files;
                     wildcardFileArray = wildcardFileArray.filter(function (file) {
                         switch (file.substring(file.length - 4)) {


### PR DESCRIPTION
Hey, wanted to submit this for you to look at. Noticed the file parsing wasn't working with the s3 choice, mostly because the browse calls were missing the optional bucket argument. This is a simplistic fix really, just pulling the name of the bucket for the custom directory. Should prolly use the browser to select the directory and allow bucket selection through that interface. More to come if you like it.

Also, if you want to merge this in at all, could you add the label `hacktoberfest-accepted`? Trying to get my approved PRs 🥇 