### PR TITLE
Fix null pointer in soundboardaudiohelper.js

### DIFF
--- a/helpers/soundboardaudiohelper.js
+++ b/helpers/soundboardaudiohelper.js
@@ -29,6 +29,9 @@ class SBAudioHelper {
     }
 
     play({src, volume}, sound) {
+        if (Howler.ctx===null) {
+            Howler.mute(false);
+        }
         if(!Howler.soundboardGain){
             Howler.soundboardGain = Howler.ctx.createGain()
             Howler.soundboardGain.connect(Howler.ctx.destination);


### PR DESCRIPTION
Got the idea for the fix from here: https://stackoverflow.com/questions/46690346/react-and-howlerjs-howler-ctx-is-null

There are probably better ways to do it.

Fixes #23 