### PR TITLE
Fix issue #24 by changing the location of soundboard gain code

### DIFF
--- a/helpers/soundboardaudiohelper.js
+++ b/helpers/soundboardaudiohelper.js
@@ -29,10 +29,7 @@ class SBAudioHelper {
     }
 
     play({src, volume}, sound) {
-        if(!Howler.soundboardGain){
-            Howler.soundboardGain = Howler.ctx.createGain()
-            Howler.soundboardGain.connect(Howler.ctx.destination);
-        }
+
         volume *= game.settings.get("core", "globalInterfaceVolume");
         let sbhowl = new Howl({src, volume, onend: (id)=>{
             this.removeActiveSound(id)
@@ -53,6 +50,12 @@ class SBAudioHelper {
             }
             this.removeActiveSound(id)
         }});
+               
+        if(!Howler.soundboardGain){
+            Howler.soundboardGain = Howler.ctx.createGain()
+            Howler.soundboardGain.connect(Howler.ctx.destination);
+        }
+
         sbhowl._sounds[0]._node.disconnect()
         sbhowl._sounds[0]._node.connect(Howler.soundboardGain);
         sbhowl.play();


### PR DESCRIPTION
Instantiating a new Howl object creates the Howler context, so we can move the code to adjust soundboard gain right after that. 

I think this is better than adding the mute(false) call - that might unmute the audio for people who have the sound muted (not 100% sure about this).