### PR TITLE
Add webm and opus file extensions

### DIFF
--- a/soundboard.js
+++ b/soundboard.js
@@ -514,6 +514,8 @@ class SoundBoard {
                         case '.ogg':
                         case '.oga':
                         case '.mp3':
+                        case '.webm':
+                        case '.opus':
                         case '.wav':
                         case 'flac':
                             return true;
@@ -536,6 +538,8 @@ class SoundBoard {
                     case '.ogg':
                     case '.oga':
                     case '.mp3':
+                    case '.webm':
+                    case '.opus':
                     case '.wav':
                     case 'flac':
                         SoundBoard.bundledSounds[dirShortName].push({


### PR DESCRIPTION
Hello there! It would be great to support webm and opus out of box rather than requiring conversion.

Browser support for these is pretty broad
https://caniuse.com/opus
https://caniuse.com/webm

As a note, I am uncertain how to test this but reading this code this seems like the correct approach to discover these associated files.